### PR TITLE
consolidate ctxtags to single Extract

### DIFF
--- a/logging/logrus/ctxlogrus/context.go
+++ b/logging/logrus/ctxlogrus/context.go
@@ -23,7 +23,7 @@ func Extract(ctx context.Context) *logrus.Entry {
 		return logrus.NewEntry(nullLogger)
 	}
 	// Add http_ctxtags tags metadata until now.
-	return l.WithFields(logrus.Fields(http_ctxtags.ExtractInboundFromCtx(ctx).Values()))
+	return l.WithFields(logrus.Fields(http_ctxtags.Extract(ctx).Values()))
 }
 
 // ToContext sets a logrus logger on the context, which can then obtained by Extract.

--- a/logging/logrus/examples_test.go
+++ b/logging/logrus/examples_test.go
@@ -14,7 +14,7 @@ func ExampleExtract_withCustomTags() {
 	handler = func(resp http.ResponseWriter, req *http.Request) {
 		// Handlers can add extra tags to `http_ctxtags` that will be set in both the extracted loggers *and*
 		// the final log statement.
-		http_ctxtags.ExtractInbound(req).Set("my_custom.my_string", "something").Set("my_custom.my_int", 1337)
+		http_ctxtags.Extract(req.Context()).Set("my_custom.my_string", "something").Set("my_custom.my_int", 1337)
 		ctxlogrus.Extract(req.Context()).Warningf("Hello World")
 	}
 }

--- a/logging/logrus/shared_test.go
+++ b/logging/logrus/shared_test.go
@@ -37,7 +37,7 @@ type loggingHandler struct {
 
 func (a *loggingHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 	assert.NotNil(a.T, ctxlogrus.Extract(req.Context()), "handlers must have access to the loggermust have ")
-	http_ctxtags.ExtractInbound(req).Set("custom_tags.string", "something").Set("custom_tags.int", 1337)
+	http_ctxtags.Extract(req.Context()).Set("custom_tags.string", "something").Set("custom_tags.int", 1337)
 	ctxlogrus.Extract(req.Context()).Warningf("handler_log")
 	httpwares_testing.PingBackHandler(httpwares_testing.DefaultPingBackStatusCode).ServeHTTP(resp, req)
 }

--- a/logging/logrus/tripperware.go
+++ b/logging/logrus/tripperware.go
@@ -48,7 +48,7 @@ func newClientRequestFields(req *http.Request) logrus.Fields {
 		"http.url.path":             req.URL.Path,
 		"http.request.length_bytes": req.ContentLength,
 	}
-	for k, v := range http_ctxtags.ExtractOutbound(req).Values() {
+	for k, v := range http_ctxtags.Extract(req.Context()).Values() {
 		fields[k] = v
 	}
 	return fields

--- a/metrics/prometheus/client_test.go
+++ b/metrics/prometheus/client_test.go
@@ -47,7 +47,7 @@ func TestPrometheusClientMetricLables(t *testing.T) {
 		http_ctxtags.Tripperware(http_ctxtags.WithServiceName("testing")),
 		func(next http.RoundTripper) http.RoundTripper {
 			return httpwares.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
-				http_ctxtags.ExtractOutbound(req).Set(http_ctxtags.TagForHandlerName, "testhandler")
+				http_ctxtags.Extract(req.Context()).Set(http_ctxtags.TagForHandlerName, "testhandler")
 				return next.RoundTrip(req)
 			})
 		},

--- a/metrics/prometheus/meta.go
+++ b/metrics/prometheus/meta.go
@@ -18,9 +18,9 @@ func reqMeta(req *http.Request, opts *options, inbound bool) *meta {
 
 	var tags map[string]interface{}
 	if inbound {
-		tags = http_ctxtags.ExtractInbound(req).Values()
+		tags = http_ctxtags.Extract(req.Context()).Values()
 	} else {
-		tags = http_ctxtags.ExtractOutbound(req).Values()
+		tags = http_ctxtags.Extract(req.Context()).Values()
 	}
 	var v interface{}
 	if m.name == "" {

--- a/tags/DOC.md
+++ b/tags/DOC.md
@@ -52,10 +52,7 @@ Tags fields are typed, and shallow and should follow the OpenTracing semantics c
   * [func WithTagExtractor(f RequestTagExtractorFunc) Option](#WithTagExtractor)
 * [type RequestTagExtractorFunc](#RequestTagExtractorFunc)
 * [type Tags](#Tags)
-  * [func ExtractInbound(req \*http.Request) \*Tags](#ExtractInbound)
-  * [func ExtractInboundFromCtx(ctx context.Context) \*Tags](#ExtractInboundFromCtx)
-  * [func ExtractOutbound(req \*http.Request) \*Tags](#ExtractOutbound)
-  * [func ExtractOutboundFromCtx(ctx context.Context) \*Tags](#ExtractOutboundFromCtx)
+  * [func Extract(ctx context.Context) \*Tags](#Extract)
   * [func (t \*Tags) Has(key string) bool](#Tags.Has)
   * [func (t \*Tags) Set(key string, value interface{}) \*Tags](#Tags.Set)
   * [func (t \*Tags) Values() map[string]interface{}](#Tags.Values)
@@ -148,7 +145,7 @@ type RequestTagExtractorFunc func(req *http.Request) map[string]interface{}
 ```
 RequestTagExtractorFunc is a signature of user-customizeable functions for extracting tags from requests.
 
-## <a name="Tags">type</a> [Tags](./context.go#L23-L25)
+## <a name="Tags">type</a> [Tags](./context.go#L19-L21)
 ``` go
 type Tags struct {
     // contains filtered or unexported fields
@@ -157,47 +154,26 @@ type Tags struct {
 Tags is the struct used for storing request tags between Context calls.
 This object is *not* thread safe, and should be handled only in the context of the request.
 
-### <a name="ExtractInbound">func</a> [ExtractInbound](./context.go#L47)
+### <a name="Extract">func</a> [Extract](./context.go#L43)
 ``` go
-func ExtractInbound(req *http.Request) *Tags
+func Extract(ctx context.Context) *Tags
 ```
-ExtractInbound returns a pre-existing Tags object in the request's Context meant for server-side.
-If the context wasn't set in the Middleware, a no-op Tag storage is returned that will *not* be propagated in context.
-
-### <a name="ExtractInboundFromCtx">func</a> [ExtractInboundFromCtx](./context.go#L53)
-``` go
-func ExtractInboundFromCtx(ctx context.Context) *Tags
-```
-ExtractInbounfFromCtx returns a pre-existing Tags object in the request's Context.
+Extract returns a pre-existing Tags object in the request's Context.
 If the context wasn't set in a tag interceptor, a no-op Tag storage is returned that will *not* be propagated in context.
 
-### <a name="ExtractOutbound">func</a> [ExtractOutbound](./context.go#L67)
-``` go
-func ExtractOutbound(req *http.Request) *Tags
-```
-ExtractOutbound returns a pre-existing Tags object in the request's Context meant for server-side.
-If the context wasn't set in the Middleware, a no-op Tag storage is returned that will *not* be propagated in context.
-
-### <a name="ExtractOutboundFromCtx">func</a> [ExtractOutboundFromCtx](./context.go#L73)
-``` go
-func ExtractOutboundFromCtx(ctx context.Context) *Tags
-```
-ExtractInbounfFromCtx returns a pre-existing Tags object in the request's Context.
-If the context wasn't set in a tag interceptor, a no-op Tag storage is returned that will *not* be propagated in context.
-
-### <a name="Tags.Has">func</a> (\*Tags) [Has](./context.go#L34)
+### <a name="Tags.Has">func</a> (\*Tags) [Has](./context.go#L30)
 ``` go
 func (t *Tags) Has(key string) bool
 ```
 Has checks if the given key exists.
 
-### <a name="Tags.Set">func</a> (\*Tags) [Set](./context.go#L28)
+### <a name="Tags.Set">func</a> (\*Tags) [Set](./context.go#L24)
 ``` go
 func (t *Tags) Set(key string, value interface{}) *Tags
 ```
 Set sets the given key in the metadata tags.
 
-### <a name="Tags.Values">func</a> (\*Tags) [Values](./context.go#L41)
+### <a name="Tags.Values">func</a> (\*Tags) [Values](./context.go#L37)
 ``` go
 func (t *Tags) Values() map[string]interface{}
 ```

--- a/tags/integration_test.go
+++ b/tags/integration_test.go
@@ -21,10 +21,10 @@ type assertingHandler struct {
 }
 
 func (a *assertingHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
-	assert.True(a, http_ctxtags.ExtractInbound(req).Has("peer.address"), "ctxtags must have peer.address at least")
-	assert.Equal(a, a.serviceName, http_ctxtags.ExtractInbound(req).Values()["http.handler.group"], "ctxtags must have the service name")
+	assert.True(a, http_ctxtags.Extract(req.Context()).Has("peer.address"), "ctxtags must have peer.address at least")
+	assert.Equal(a, a.serviceName, http_ctxtags.Extract(req.Context()).Values()["http.handler.group"], "ctxtags must have the service name")
 	if a.methodName != "" {
-		assert.Equal(a, a.methodName, http_ctxtags.ExtractInbound(req).Values()["http.handler.name"], "ctxtags must have the method name set")
+		assert.Equal(a, a.methodName, http_ctxtags.Extract(req.Context()).Values()["http.handler.name"], "ctxtags must have the method name set")
 	}
 
 	httpwares_testing.PingBackHandler(httpwares_testing.DefaultPingBackStatusCode).ServeHTTP(resp, req)
@@ -69,7 +69,7 @@ func (s *TaggingSuite) TestDefaultTagsAreSet() {
 	resp, err := client.Do(req)
 	require.NoError(s.T(), err, "call shouldn't fail")
 	require.Equal(s.T(), httpwares_testing.DefaultPingBackStatusCode, resp.StatusCode, "response should have the same type")
-	requestTags := http_ctxtags.ExtractOutbound(resp.Request)
+	requestTags := http_ctxtags.Extract(resp.Request.Context())
 	assert.NotEmpty(s.T(), requestTags, "request leaving client has tags from client tripperware")
 	assert.Equal(s.T(), "someclientservice", requestTags.Values()["http.call.service"], "request leaving client has tags from client tripperware")
 
@@ -81,7 +81,7 @@ func (s *TaggingSuite) TestCustomTagsAreBeingUsed() {
 	resp, err := client.Do(req)
 	require.NoError(s.T(), err, "call shouldn't fail")
 	require.Equal(s.T(), httpwares_testing.DefaultPingBackStatusCode, resp.StatusCode, "response should have the same type")
-	requestTags := http_ctxtags.ExtractOutbound(resp.Request)
+	requestTags := http_ctxtags.Extract(resp.Request.Context())
 	assert.NotEmpty(s.T(), requestTags, "request leaving client has tags from client tripperware")
 	assert.Equal(s.T(), "MyServiceCapitalised", requestTags.Values()["http.call.service"], "request should have serviceName updated by TagRequest")
 }

--- a/tags/middleware.go
+++ b/tags/middleware.go
@@ -18,7 +18,7 @@ func Middleware(handlerGroupName string, opts ...Option) httpwares.Middleware {
 	o := evaluateOptions(opts)
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
-			t := ExtractInboundFromCtx(req.Context()) // will allocate a new one if it didn't exist.
+			t := Extract(req.Context()) // will allocate a new one if it didn't exist.
 			needUpdatingContext := true
 			if len(t.Values()) > 0 {
 				needUpdatingContext = false
@@ -34,7 +34,7 @@ func Middleware(handlerGroupName string, opts ...Option) httpwares.Middleware {
 			t.Set(TagForHandlerGroup, handlerGroupName)
 			newReq := req
 			if needUpdatingContext {
-				newReq = req.WithContext(setInboundInContext(req.Context(), t))
+				newReq = req.WithContext(setInContext(req.Context(), t))
 			}
 			next.ServeHTTP(resp, newReq)
 		})
@@ -49,7 +49,7 @@ func Middleware(handlerGroupName string, opts ...Option) httpwares.Middleware {
 func HandlerName(handlerName string) httpwares.Middleware {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
-			t := ExtractInbound(req)
+			t := Extract(req.Context())
 			t.Set(TagForHandlerName, handlerName)
 			next.ServeHTTP(resp, req)
 		})

--- a/tags/tripperware.go
+++ b/tags/tripperware.go
@@ -11,7 +11,7 @@ func Tripperware(opts ...Option) httpwares.Tripperware {
 	o := evaluateOptions(opts)
 	return func(next http.RoundTripper) http.RoundTripper {
 		return httpwares.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
-			t := ExtractOutbound(req) // will allocate a new one if it didn't exist.
+			t := Extract(req.Context()) // will allocate a new one if it didn't exist.
 			defaultRequestTags(t, req)
 			for _, extractor := range o.tagExtractors {
 				if output := extractor(req); output != nil {
@@ -30,7 +30,7 @@ func Tripperware(opts ...Option) httpwares.Tripperware {
 				}
 			}
 
-			newReq := setOutboundInRequest(req, t)
+			newReq := req.WithContext(setInContext(req.Context(), t))
 			return next.RoundTrip(newReq)
 		})
 	}

--- a/tracing/debug/middleware.go
+++ b/tracing/debug/middleware.go
@@ -34,7 +34,7 @@ func Middleware(opts ...Option) httpwares.Middleware {
 			next.ServeHTTP(newResp, req)
 
 			tr.LazyPrintf("tags: ")
-			for k, v := range http_ctxtags.ExtractInbound(req).Values() {
+			for k, v := range http_ctxtags.Extract(req.Context()).Values() {
 				tr.LazyPrintf("%v: %v", k, v)
 			}
 			tr.LazyPrintf("Response: %d", newResp.StatusCode())
@@ -47,7 +47,7 @@ func Middleware(opts ...Option) httpwares.Middleware {
 }
 
 func operationNameFromReqHandler(req *http.Request) string {
-	if tags := http_ctxtags.ExtractInbound(req); tags.Has(http_ctxtags.TagForHandlerGroup) {
+	if tags := http_ctxtags.Extract(req.Context()); tags.Has(http_ctxtags.TagForHandlerGroup) {
 		vals := tags.Values()
 		method := "unknown"
 		if val, ok := vals[http_ctxtags.TagForHandlerName].(string); ok {

--- a/tracing/debug/tripperware.go
+++ b/tracing/debug/tripperware.go
@@ -36,7 +36,7 @@ func Tripperware(opts ...Option) httpwares.Tripperware {
 
 			resp, err := next.RoundTrip(req)
 
-			tr.LazyPrintf("%s", fmtTags(http_ctxtags.ExtractInbound(req).Values()))
+			tr.LazyPrintf("%s", fmtTags(http_ctxtags.Extract(req.Context()).Values()))
 
 			if err != nil {
 				tr.LazyPrintf("Error on response: %v", err)
@@ -54,7 +54,7 @@ func Tripperware(opts ...Option) httpwares.Tripperware {
 }
 
 func operationNameFromUrl(req *http.Request) string {
-	if tags := http_ctxtags.ExtractOutbound(req); tags.Has(http_ctxtags.TagForCallService) {
+	if tags := http_ctxtags.Extract(req.Context()); tags.Has(http_ctxtags.TagForCallService) {
 		vals := tags.Values()
 		return fmt.Sprintf("%v.%s", vals[http_ctxtags.TagForCallService], req.Method)
 	}

--- a/tracing/opentracing/integration_test.go
+++ b/tracing/opentracing/integration_test.go
@@ -34,7 +34,7 @@ type assertingHandler struct {
 
 func (a *assertingHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
 	assert.NotNil(a.T, opentracing.SpanFromContext(req.Context()), "handlers must have the spancontext in their context, otherwise propagation will fail")
-	tags := http_ctxtags.ExtractInbound(req)
+	tags := http_ctxtags.Extract(req.Context())
 	assert.True(a.T, tags.Has("trace.traceid"), "handlers should see traceid in tags")
 	assert.True(a.T, tags.Has("trace.spanid"), "handlers should see traceid in tags")
 	httpwares_testing.PingBackHandler(httpwares_testing.DefaultPingBackStatusCode).ServeHTTP(resp, req)

--- a/tracing/opentracing/middleware.go
+++ b/tracing/opentracing/middleware.go
@@ -28,7 +28,7 @@ func Middleware(opts ...Option) httpwares.Middleware {
 				next.ServeHTTP(resp, req)
 				return
 			}
-			tags := http_ctxtags.ExtractInbound(req)
+			tags := http_ctxtags.Extract(req.Context())
 			newReq, serverSpan := newServerSpanFromInbound(req, o.tracer)
 			hackyInjectOpentracingIdsToTags(serverSpan, tags)
 			newResp := httpwares.WrapResponseWriter(resp)
@@ -68,7 +68,7 @@ func newServerSpanFromInbound(req *http.Request, tracer opentracing.Tracer) (*ht
 }
 
 func operationNameFromReqHandler(req *http.Request) string {
-	if tags := http_ctxtags.ExtractInbound(req); tags.Has(http_ctxtags.TagForHandlerGroup) {
+	if tags := http_ctxtags.Extract(req.Context()); tags.Has(http_ctxtags.TagForHandlerGroup) {
 		vals := tags.Values()
 		method := "unknown"
 		if val, ok := vals[http_ctxtags.TagForHandlerName].(string); ok {

--- a/tracing/opentracing/tripperware.go
+++ b/tracing/opentracing/tripperware.go
@@ -64,7 +64,7 @@ func newClientSpanFromRequest(req *http.Request, tracer opentracing.Tracer) (*ht
 }
 
 func operationNameFromUrl(req *http.Request) string {
-	if tags := http_ctxtags.ExtractOutbound(req); tags.Has(http_ctxtags.TagForCallService) {
+	if tags := http_ctxtags.Extract(req.Context()); tags.Has(http_ctxtags.TagForCallService) {
 		vals := tags.Values()
 		return fmt.Sprintf("%v:%s", vals[http_ctxtags.TagForCallService], req.Method)
 	}


### PR DESCRIPTION
Rather than have a number of `Extract ... ` methods on `http_ctxtags` it makes it easier to understand if a single extract method is in the package. This can be used in both the middleware and tripperware.