### PR TITLE
adding a decider onto middleware so that logs can be surpessed

### DIFF
--- a/logging/logrus/DOC.md
+++ b/logging/logrus/DOC.md
@@ -149,13 +149,13 @@ The body will be recorded as a separate log message. Body of `application/json` 
 http.request.body_json (in structured JSON form) and others will be captured as http.request.body_raw logrus field
 (raw base64-encoded value).
 
-## <a name="DefaultMiddlewareCodeToLevel">func</a> [DefaultMiddlewareCodeToLevel](./options.go#L112)
+## <a name="DefaultMiddlewareCodeToLevel">func</a> [DefaultMiddlewareCodeToLevel](./options.go#L111)
 ``` go
 func DefaultMiddlewareCodeToLevel(httpStatusCode int) logrus.Level
 ```
 DefaultMiddlewareCodeToLevel is the default of a mapper between HTTP server-side status codes and logrus log levels.
 
-## <a name="DefaultTripperwareCodeToLevel">func</a> [DefaultTripperwareCodeToLevel](./options.go#L125)
+## <a name="DefaultTripperwareCodeToLevel">func</a> [DefaultTripperwareCodeToLevel](./options.go#L124)
 ``` go
 func DefaultTripperwareCodeToLevel(httpStatusCode int) logrus.Level
 ```
@@ -196,30 +196,30 @@ Tripperware is a server-side http ware for logging using logrus.
 This tripperware *does not* propagate a context-based logger, but act as a logger of requests.
 This includes logging of errors.
 
-## <a name="CodeToLevel">type</a> [CodeToLevel](./options.go#L51)
+## <a name="CodeToLevel">type</a> [CodeToLevel](./options.go#L50)
 ``` go
 type CodeToLevel func(httpStatusCode int) logrus.Level
 ```
 CodeToLevel user functions define the mapping between HTTP status codes and logrus log levels.
 
-## <a name="Decider">type</a> [Decider](./options.go#L109)
+## <a name="Decider">type</a> [Decider](./options.go#L108)
 ``` go
 type Decider func(w httpwares.WrappedResponseWriter, r *http.Request) bool
 ```
 Decider function defines rules for suppressing any interceptor logs
 
-## <a name="Option">type</a> [Option](./options.go#L48)
+## <a name="Option">type</a> [Option](./options.go#L47)
 ``` go
 type Option func(*options)
 ```
 
-### <a name="WithConnectivityErrorLevel">func</a> [WithConnectivityErrorLevel](./options.go#L64)
+### <a name="WithConnectivityErrorLevel">func</a> [WithConnectivityErrorLevel](./options.go#L63)
 ``` go
 func WithConnectivityErrorLevel(level logrus.Level) Option
 ```
 WithConnectivityErrorLevel customizes
 
-### <a name="WithDecider">func</a> [WithDecider](./options.go#L102)
+### <a name="WithDecider">func</a> [WithDecider](./options.go#L101)
 ``` go
 func WithDecider(f Decider) Option
 ```
@@ -243,7 +243,7 @@ Middleware(logrus.WithField("decider", "test"),
 ```
 
 </details>
-### <a name="WithLevels">func</a> [WithLevels](./options.go#L57)
+### <a name="WithLevels">func</a> [WithLevels](./options.go#L56)
 ``` go
 func WithLevels(f CodeToLevel) Option
 ```
@@ -252,7 +252,7 @@ WithLevels customizes the function that maps HTTP client or server side status c
 By default `DefaultMiddlewareCodeToLevel` is used for server-side middleware, and `DefaultTripperwareCodeToLevel`
 is used for client-side tripperware.
 
-### <a name="WithRequestBodyCapture">func</a> [WithRequestBodyCapture](./options.go#L82)
+### <a name="WithRequestBodyCapture">func</a> [WithRequestBodyCapture](./options.go#L81)
 ``` go
 func WithRequestBodyCapture(deciderFunc func(r *http.Request) bool) Option
 ```
@@ -269,7 +269,7 @@ For middleware, only requests with a set Content-Length will be captured, with n
 
 This option creates a copy of the body per request, so please use with care.
 
-### <a name="WithResponseBodyCapture">func</a> [WithResponseBodyCapture](./options.go#L95)
+### <a name="WithResponseBodyCapture">func</a> [WithResponseBodyCapture](./options.go#L94)
 ``` go
 func WithResponseBodyCapture(deciderFunc func(r *http.Request, status int) bool) Option
 ```

--- a/logging/logrus/example_test.go
+++ b/logging/logrus/example_test.go
@@ -1,6 +1,7 @@
 package http_logrus
 
 import (
+	"github.com/improbable-eng/go-httpwares"
 	"github.com/improbable-eng/go-httpwares/logging/logrus/ctxlogrus"
 	"github.com/sirupsen/logrus"
 	"net/http"
@@ -15,4 +16,16 @@ func ExampleMiddleware() {
 	if err := http.ListenAndServe(":8080", hm); err != nil {
 		panic(err)
 	}
+}
+
+func ExampleWithDecider() {
+	Middleware(logrus.WithField("decider", "test"),
+		WithDecider(func(w httpwares.WrappedResponseWriter, r *http.Request) bool {
+			if r.URL.Path == "/nolog" {
+				// do not want to log request to this endpoint
+				return false
+			}
+			return true
+		}),
+	)
 }

--- a/logging/logrus/middleware.go
+++ b/logging/logrus/middleware.go
@@ -35,8 +35,12 @@ func Middleware(entry *logrus.Entry, opts ...Option) httpwares.Middleware {
 			})
 			startTime := time.Now()
 			nextHandler.ServeHTTP(wrappedResp, newReq)
-			capture.finish() // captureResponse has a nil check, this can be nil
 
+			if !o.shouldLog(wrappedResp, newReq) {
+				return
+			}
+
+			capture.finish() // captureResponse has a nil check, this can be nil
 			postCallFields := logrus.Fields{
 				"http.status":  wrappedResp.StatusCode(),
 				"http.time_ms": timeDiffToMilliseconds(startTime),

--- a/logging/logrus/middleware.go
+++ b/logging/logrus/middleware.go
@@ -36,7 +36,7 @@ func Middleware(entry *logrus.Entry, opts ...Option) httpwares.Middleware {
 			startTime := time.Now()
 			nextHandler.ServeHTTP(wrappedResp, newReq)
 
-			if !o.shouldLog(wrappedResp, newReq) {
+			if o.shouldLog != nil && !o.shouldLog(wrappedResp, newReq) {
 				return
 			}
 

--- a/logging/logrus/middleware_test.go
+++ b/logging/logrus/middleware_test.go
@@ -34,10 +34,7 @@ func TestLogrusMiddlewareSuite(t *testing.T) {
 		http_logrus.Middleware(
 			logrus.NewEntry(s.logrusBaseTestSuite.logger).WithField("http.handler.group", "my_service"),
 			http_logrus.WithDecider(func(w httpwares.WrappedResponseWriter, r *http.Request) bool {
-				if r.URL.Path == "/blah" {
-					return false
-				}
-				return true
+				return r.URL.Path != "/blah"
 			}),
 			http_logrus.WithLevels(customMiddlewareCodeToLevel),
 			http_logrus.WithRequestBodyCapture(requestCaptureDeciderForTest),

--- a/logging/logrus/options.go
+++ b/logging/logrus/options.go
@@ -13,7 +13,6 @@ var (
 		levelForConnectivityError: logrus.WarnLevel,
 		requestCaptureFunc:        func(r *http.Request) bool { return false },
 		responseCaptureFunc:       func(r *http.Request, status int) bool { return false },
-		shouldLog:                 defaultDeciderMethod,
 	}
 )
 
@@ -130,8 +129,4 @@ func DefaultTripperwareCodeToLevel(httpStatusCode int) logrus.Level {
 	} else {
 		return logrus.WarnLevel
 	}
-}
-
-func defaultDeciderMethod(w httpwares.WrappedResponseWriter, r *http.Request) bool {
-	return true
 }


### PR DESCRIPTION
Adding a `decider` method so that we can decide that we do not want to log messages for certain calls.