### PR TITLE
moving inline with grpc middlewear - now logging all tags

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -28,8 +28,25 @@
 [[projects]]
   branch = "master"
   name = "github.com/golang/protobuf"
-  packages = ["jsonpb","proto","ptypes/struct"]
+  packages = [
+    "jsonpb",
+    "proto",
+    "ptypes",
+    "ptypes/any",
+    "ptypes/duration",
+    "ptypes/struct",
+    "ptypes/timestamp"
+  ]
   revision = "1e59b77b52bf8e4b449a57e6f79f21226d571845"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/grpc-ecosystem/go-grpc-middleware"
+  packages = [
+    ".",
+    "tags"
+  ]
+  revision = "d0c54e68681ec7999ac17864470f3bee6521ba2b"
 
 [[projects]]
   name = "github.com/matttproud/golang_protobuf_extensions"
@@ -40,12 +57,20 @@
 [[projects]]
   branch = "master"
   name = "github.com/mwitkow/go-conntrack"
-  packages = [".","connhelpers"]
+  packages = [
+    ".",
+    "connhelpers"
+  ]
   revision = "cc309e4a22231782e8893f3c35ced0967807a33e"
 
 [[projects]]
   name = "github.com/opentracing/opentracing-go"
-  packages = [".","ext","log","mocktracer"]
+  packages = [
+    ".",
+    "ext",
+    "log",
+    "mocktracer"
+  ]
   revision = "1949ddbfd147afd4d964a9f00b24eb291e0e7c38"
   version = "v1.0.2"
 
@@ -70,13 +95,20 @@
 [[projects]]
   branch = "master"
   name = "github.com/prometheus/common"
-  packages = ["expfmt","internal/bitbucket.org/ww/goautoneg","model"]
+  packages = [
+    "expfmt",
+    "internal/bitbucket.org/ww/goautoneg",
+    "model"
+  ]
   revision = "2e54d0b93cba2fd133edc32211dcc32c06ef72ca"
 
 [[projects]]
   branch = "master"
   name = "github.com/prometheus/procfs"
-  packages = [".","xfs"]
+  packages = [
+    ".",
+    "xfs"
+  ]
   revision = "a6e9df898b1336106c743392c48ee0b71f5c4efa"
 
 [[projects]]
@@ -87,7 +119,11 @@
 
 [[projects]]
   name = "github.com/stretchr/testify"
-  packages = ["assert","require","suite"]
+  packages = [
+    "assert",
+    "require",
+    "suite"
+  ]
   revision = "69483b4bd14f5845b5a1e55bca19e954e827f1d0"
   version = "v1.1.4"
 
@@ -100,30 +136,108 @@
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
-  packages = ["context","context/ctxhttp","http2","http2/hpack","idna","internal/timeseries","lex/httplex","trace"]
+  packages = [
+    "context",
+    "context/ctxhttp",
+    "http2",
+    "http2/hpack",
+    "idna",
+    "internal/timeseries",
+    "lex/httplex",
+    "trace"
+  ]
   revision = "d866cfc389cec985d6fda2859936a575a55a3ab6"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/sys"
-  packages = ["unix","windows"]
+  packages = [
+    "unix",
+    "windows"
+  ]
   revision = "76c138986e66b22cbf82122ac886457fb5226957"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/text"
-  packages = ["collate","collate/build","internal/colltab","internal/gen","internal/tag","internal/triegen","internal/ucd","language","secure/bidirule","transform","unicode/bidi","unicode/cldr","unicode/norm","unicode/rangetable"]
+  packages = [
+    "collate",
+    "collate/build",
+    "internal/colltab",
+    "internal/gen",
+    "internal/tag",
+    "internal/triegen",
+    "internal/ucd",
+    "language",
+    "secure/bidirule",
+    "transform",
+    "unicode/bidi",
+    "unicode/cldr",
+    "unicode/norm",
+    "unicode/rangetable"
+  ]
   revision = "c4d099d611ac3ded35360abf03581e13d91c828f"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/tools"
-  packages = ["container/intsets","go/ast/astutil","go/buildutil","go/callgraph","go/loader","go/pointer","go/ssa","go/ssa/ssautil","go/types/typeutil","godoc","godoc/analysis","godoc/util","godoc/vfs","godoc/vfs/httpfs"]
+  packages = [
+    "container/intsets",
+    "go/ast/astutil",
+    "go/buildutil",
+    "go/callgraph",
+    "go/loader",
+    "go/pointer",
+    "go/ssa",
+    "go/ssa/ssautil",
+    "go/types/typeutil",
+    "godoc",
+    "godoc/analysis",
+    "godoc/util",
+    "godoc/vfs",
+    "godoc/vfs/httpfs"
+  ]
   revision = "64890f4e2b733655fee5077a5435a8812404c3a3"
+
+[[projects]]
+  branch = "master"
+  name = "google.golang.org/genproto"
+  packages = ["googleapis/rpc/status"]
+  revision = "2b5a72b8730b0b16380010cfe5286c42108d88e7"
+
+[[projects]]
+  name = "google.golang.org/grpc"
+  packages = [
+    ".",
+    "balancer",
+    "balancer/base",
+    "balancer/roundrobin",
+    "codes",
+    "connectivity",
+    "credentials",
+    "encoding",
+    "encoding/proto",
+    "grpclb/grpc_lb_v1/messages",
+    "grpclog",
+    "internal",
+    "keepalive",
+    "metadata",
+    "naming",
+    "peer",
+    "resolver",
+    "resolver/dns",
+    "resolver/passthrough",
+    "stats",
+    "status",
+    "tap",
+    "transport"
+  ]
+  revision = "8e4536a86ab602859c20df5ebfd0bd4228d08655"
+  version = "v1.10.0"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "2976d2178f4e3fd4609692e11f9c671ea9bb5e53679631206c1b4347ec709a5e"
+  inputs-digest = "45111347708b36819b492b1723ab8d2d01f1268533048eed66fc2ec374bd9857"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/logging/logrus/ctxlogrus/DOC.md
+++ b/logging/logrus/ctxlogrus/DOC.md
@@ -18,6 +18,7 @@ Additional fields can be added to the logger on the context by with the AddField
 
 ## <a name="pkg-imports">Imported Packages</a>
 
+- [github.com/grpc-ecosystem/go-grpc-middleware/tags](https://godoc.org/github.com/grpc-ecosystem/go-grpc-middleware/tags)
 - [github.com/sirupsen/logrus](https://godoc.org/github.com/sirupsen/logrus)
 - [golang.org/x/net/context](https://godoc.org/golang.org/x/net/context)
 
@@ -34,7 +35,7 @@ Additional fields can be added to the logger on the context by with the AddField
 #### <a name="pkg-files">Package files</a>
 [context.go](./context.go) [doc.go](./doc.go) [noop.go](./noop.go) 
 
-## <a name="AddFields">func</a> [AddFields](./context.go#L40)
+## <a name="AddFields">func</a> [AddFields](./context.go#L45)
 ``` go
 func AddFields(ctx context.Context, fields logrus.Fields)
 ```
@@ -53,7 +54,7 @@ ctxlogrus.AddFields(ctx, logrus.Fields{"num": 42})
 
 </details>
 
-## <a name="Extract">func</a> [Extract](./context.go#L25)
+## <a name="Extract">func</a> [Extract](./context.go#L26)
 ``` go
 func Extract(ctx context.Context) *logrus.Entry
 ```
@@ -77,7 +78,7 @@ entry.Info("logging")
 
 </details>
 
-## <a name="ToContext">func</a> [ToContext](./context.go#L53)
+## <a name="ToContext">func</a> [ToContext](./context.go#L58)
 ``` go
 func ToContext(ctx context.Context, entry *logrus.Entry) context.Context
 ```

--- a/logging/logrus/ctxlogrus/context.go
+++ b/logging/logrus/ctxlogrus/context.go
@@ -1,6 +1,7 @@
 package ctxlogrus
 
 import (
+	"github.com/grpc-ecosystem/go-grpc-middleware/tags"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 )
@@ -30,6 +31,10 @@ func Extract(ctx context.Context) *logrus.Entry {
 
 	fields := logrus.Fields{}
 	for k, v := range l.fields {
+		fields[k] = v
+	}
+
+	for k, v := range grpc_ctxtags.Extract(ctx).Values() {
 		fields[k] = v
 	}
 

--- a/logging/logrus/middleware_test.go
+++ b/logging/logrus/middleware_test.go
@@ -58,7 +58,7 @@ type logrusMiddlewareTestSuite struct {
 	*logrusBaseTestSuite
 }
 
-func (s *logrusMiddlewareTestSuite) TestPing_WithCustomTags() {
+func (s *logrusMiddlewareTestSuite) TestPing_WithCustomFields() {
 	req, _ := http.NewRequest("GET", "https://something.local/someurl", nil)
 	req.Header.Set("User-Agent", "testagent")
 	req.Header.Set("referer", "http://improbable.io/")


### PR DESCRIPTION
Bringing inline with the behaviour in gRPC middleware ... we now log all tags that are present on the request as well as the fields that have been explicitly added.