### PR TITLE
Removed unnecessary status label from http_handler_request_size_bytes

### DIFF
--- a/metrics/prometheus/server.go
+++ b/metrics/prometheus/server.go
@@ -43,7 +43,7 @@ var (
 			Help:    "Size of received requests.",
 			Buckets: prometheus.ExponentialBuckets(32, 32, 6),
 		},
-		[]string{"name", "handler", "host", "path", "method", "status"},
+		[]string{"name", "handler", "host", "path", "method"},
 	)
 	serverResponseSize = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{


### PR DESCRIPTION
Removed status label from metric that doesn't require it. The `RequestRead` function call further down does not pass the status in, thus causing a prometheus to panic.