### PR TITLE
Remove status code from request size metric

### DIFF
--- a/metrics/prometheus/client.go
+++ b/metrics/prometheus/client.go
@@ -42,7 +42,7 @@ var (
 			Help:    "Size of sent requests.",
 			Buckets: prometheus.ExponentialBuckets(32, 32, 6),
 		},
-		[]string{"name", "handler", "host", "path", "method", "status"},
+		[]string{"name", "handler", "host", "path", "method"},
 	)
 	clientResponseSize = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{


### PR DESCRIPTION
When we receive a request to track RequestRead we don't yet know
what the response code is. Only until ResponseStarted or ResponseDone
do we know. As we don't know, this results in a panic as prometheus
is expecting 6 labels but only receives 5.