### PR TITLE
retry: Allow setup of buffer for request body if GetBody property…

### DIFF
--- a/retry/get_body_go17.go
+++ b/retry/get_body_go17.go
@@ -29,3 +29,7 @@ func getBody(r *http.Request) func() (io.ReadCloser, error) {
 	}
 	return nil
 }
+
+func RemoveGetBody(r *http.Request) {
+	// no-op
+}

--- a/retry/get_body_go17.go
+++ b/retry/get_body_go17.go
@@ -26,6 +26,10 @@ func getBody(r *http.Request) func() (io.ReadCloser, error) {
 			b := bytes.NewBuffer(body)
 			return ioutil.NopCloser(b), nil
 		}
+	} else {
+		// No buffering required as there is no body
+		return func() (io.ReadCloser, error) {
+			return nil, nil
+		}
 	}
-	return nil
 }

--- a/retry/get_body_go17.go
+++ b/retry/get_body_go17.go
@@ -29,7 +29,3 @@ func getBody(r *http.Request) func() (io.ReadCloser, error) {
 	}
 	return nil
 }
-
-func RemoveGetBody(r *http.Request) {
-	// no-op
-}

--- a/retry/get_body_go18.go
+++ b/retry/get_body_go18.go
@@ -3,14 +3,31 @@
 package http_retry
 
 import (
+	"bytes"
 	"io"
+	"io/ioutil"
 	"net/http"
 )
 
 func getBody(r *http.Request) func() (io.ReadCloser, error) {
-	return r.GetBody
-}
-
-func RemoveGetBody(r *http.Request) {
-	r.GetBody = nil
+	if r.GetBody != nil {
+		return r.GetBody
+	} else if r.Body != nil {
+		// If the GetBody function does not exist, setup our own buffering for the body to allow re-reads
+		data, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			return func() (io.ReadCloser, error) {
+				return nil, err
+			}
+		}
+		return func() (io.ReadCloser, error) {
+			// Create a new buffer containing the body data each time
+			return ioutil.NopCloser(bytes.NewBuffer(data)), nil
+		}
+	} else {
+		// No buffering required as there is no body
+		return func() (io.ReadCloser, error) {
+			return nil, nil
+		}
+	}
 }

--- a/retry/get_body_go18.go
+++ b/retry/get_body_go18.go
@@ -10,3 +10,7 @@ import (
 func getBody(r *http.Request) func() (io.ReadCloser, error) {
 	return r.GetBody
 }
+
+func RemoveGetBody(r *http.Request) {
+	r.GetBody = nil
+}

--- a/retry/integration_test.go
+++ b/retry/integration_test.go
@@ -188,19 +188,12 @@ func (s *RetryTripperwareSuite) TestCustomResponseDiscarder() {
 	s.ClientTripperware = clientTripperware
 }
 
-func (s *RetryTripperwareSuite) TestBodyBuffering() {
+func (s *RetryTripperwareSuite) TestRequestBodyBuffering() {
 	s.f.resetFailingConfiguration(3, noSleep)
-	clientTripperware := s.ClientTripperware
-	s.ClientTripperware = []httpwares.Tripperware{
-		http_retry.Tripperware(
-			http_retry.WithBodyBuffering(),
-		),
-	}
 	req := s.createRequest("GET", s.SimpleCtx())
-	req.GetBody = nil
+	http_retry.RemoveGetBody(req)
 	resp, err := s.NewClient().Do(req)
 	require.NoError(s.T(), err, "call shouldn't fail")
 	require.Equal(s.T(), httpwares_testing.DefaultPingBackStatusCode, resp.StatusCode, "response should succeed")
 	require.EqualValues(s.T(), 3, s.f.requestCount(), "3 requests should be retried to meet the modulo")
-	s.ClientTripperware = clientTripperware
 }

--- a/retry/integration_test.go
+++ b/retry/integration_test.go
@@ -25,8 +25,7 @@ var (
 	noSleep         = 0 * time.Second
 	retryTimeout    = 50 * time.Millisecond
 	failureCode     = http.StatusServiceUnavailable
-	testContent     = "SomeReallyLongString"
-	expectedContent = testContent
+	expectedContent = "SomeReallyLongString"
 )
 
 type failingHandler struct {
@@ -205,11 +204,12 @@ func (s *RetryTripperwareSuite) TestRequestBodyBuffering() {
 
 func (s *RetryTripperwareSuite) TestRequestBodyBufferingWithNoBody() {
 	s.f.resetFailingConfiguration(3, noSleep)
+	storedContent := expectedContent
 	expectedContent = ""
 	req := s.createRequest("GET", s.SimpleCtx(), "")
 	resp, err := s.NewClient().Do(req)
 	require.NoError(s.T(), err, "call shouldn't fail")
 	require.Equal(s.T(), httpwares_testing.DefaultPingBackStatusCode, resp.StatusCode, "response should succeed")
 	require.EqualValues(s.T(), 3, s.f.requestCount(), "3 requests should be retried to meet the modulo")
-	expectedContent = testContent
+	expectedContent = storedContent
 }

--- a/retry/integration_test.go
+++ b/retry/integration_test.go
@@ -187,3 +187,20 @@ func (s *RetryTripperwareSuite) TestCustomResponseDiscarder() {
 	require.EqualValues(s.T(), 5, s.f.requestCount(), "backend should see all the retry calls")
 	s.ClientTripperware = clientTripperware
 }
+
+func (s *RetryTripperwareSuite) TestBodyBuffering() {
+	s.f.resetFailingConfiguration(3, noSleep)
+	clientTripperware := s.ClientTripperware
+	s.ClientTripperware = []httpwares.Tripperware{
+		http_retry.Tripperware(
+			http_retry.WithBodyBuffering(),
+		),
+	}
+	req := s.createRequest("GET", s.SimpleCtx())
+	req.GetBody = nil
+	resp, err := s.NewClient().Do(req)
+	require.NoError(s.T(), err, "call shouldn't fail")
+	require.Equal(s.T(), httpwares_testing.DefaultPingBackStatusCode, resp.StatusCode, "response should succeed")
+	require.EqualValues(s.T(), 3, s.f.requestCount(), "3 requests should be retried to meet the modulo")
+	s.ClientTripperware = clientTripperware
+}

--- a/retry/options.go
+++ b/retry/options.go
@@ -10,18 +10,20 @@ import (
 
 var (
 	defaultOptions = &options{
-		decider:     DefaultRetriableDecider,
-		discarder:   DefaultResponseDiscarder,
-		maxRetry:    3,
-		backoffFunc: BackoffLinear(100 * time.Millisecond),
+		decider:              DefaultRetriableDecider,
+		discarder:            DefaultResponseDiscarder,
+		maxRetry:             3,
+		backoffFunc:          BackoffLinear(100 * time.Millisecond),
+		bodyBufferingAllowed: false,
 	}
 )
 
 type options struct {
-	decider     RequestRetryDeciderFunc
-	discarder   ResponseDiscarderFunc
-	maxRetry    uint
-	backoffFunc BackoffFunc
+	decider              RequestRetryDeciderFunc
+	discarder            ResponseDiscarderFunc
+	maxRetry             uint
+	backoffFunc          BackoffFunc
+	bodyBufferingAllowed bool
 }
 
 func evaluateOptions(opts []Option) *options {
@@ -74,6 +76,16 @@ func WithDecider(f RequestRetryDeciderFunc) Option {
 func WithResponseDiscarder(f ResponseDiscarderFunc) Option {
 	return func(o *options) {
 		o.discarder = f
+	}
+}
+
+// WithBodyBuffering allows the retry tripperware to setup buffering of the request body if the GetBody
+// property of the request is not present.
+// Without this, requests with no GetBody cannot be retried as the body cannot be read multiple times.
+// This should be used whenever wa want to retry requests with no GetBody method. For example, when used in a proxy.
+func WithBodyBuffering() Option {
+	return func(o *options) {
+		o.bodyBufferingAllowed = true
 	}
 }
 

--- a/retry/options.go
+++ b/retry/options.go
@@ -10,20 +10,18 @@ import (
 
 var (
 	defaultOptions = &options{
-		decider:              DefaultRetriableDecider,
-		discarder:            DefaultResponseDiscarder,
-		maxRetry:             3,
-		backoffFunc:          BackoffLinear(100 * time.Millisecond),
-		bodyBufferingAllowed: false,
+		decider:     DefaultRetriableDecider,
+		discarder:   DefaultResponseDiscarder,
+		maxRetry:    3,
+		backoffFunc: BackoffLinear(100 * time.Millisecond),
 	}
 )
 
 type options struct {
-	decider              RequestRetryDeciderFunc
-	discarder            ResponseDiscarderFunc
-	maxRetry             uint
-	backoffFunc          BackoffFunc
-	bodyBufferingAllowed bool
+	decider     RequestRetryDeciderFunc
+	discarder   ResponseDiscarderFunc
+	maxRetry    uint
+	backoffFunc BackoffFunc
 }
 
 func evaluateOptions(opts []Option) *options {
@@ -76,16 +74,6 @@ func WithDecider(f RequestRetryDeciderFunc) Option {
 func WithResponseDiscarder(f ResponseDiscarderFunc) Option {
 	return func(o *options) {
 		o.discarder = f
-	}
-}
-
-// WithBodyBuffering allows the retry tripperware to setup buffering of the request body if the GetBody
-// property of the request is not present.
-// Without this, requests with no GetBody cannot be retried as the body cannot be read multiple times.
-// This should be used whenever wa want to retry requests with no GetBody method. For example, when used in a proxy.
-func WithBodyBuffering() Option {
-	return func(o *options) {
-		o.bodyBufferingAllowed = true
 	}
 }
 

--- a/retry/remove_body_go17_test.go
+++ b/retry/remove_body_go17_test.go
@@ -2,6 +2,8 @@
 
 package http_retry_test
 
+import "net/http"
+
 func removeGetBody(r *http.Request) {
 	// no-op
 }

--- a/retry/remove_body_go17_test.go
+++ b/retry/remove_body_go17_test.go
@@ -1,0 +1,7 @@
+// +build go1.7,!go1.8
+
+package http_retry_test
+
+func removeGetBody(r *http.Request) {
+	// no-op
+}

--- a/retry/remove_body_go18_test.go
+++ b/retry/remove_body_go18_test.go
@@ -1,0 +1,9 @@
+// +build go1.8
+
+package http_retry_test
+
+import "net/http"
+
+func removeGetBody(r *http.Request) {
+	r.GetBody = nil
+}

--- a/retry/tripperware.go
+++ b/retry/tripperware.go
@@ -34,7 +34,8 @@ func Tripperware(opts ...Option) httpwares.Tripperware {
 			}
 
 			getBodyFn := getBody(req)
-			if getBodyFn == nil && o.bodyBufferingAllowed && req.Body != nil {
+			if getBodyFn == nil && req.Body != nil {
+				// If the GetBody function does not exist, we can setup our own buffering for the body
 				data, err := ioutil.ReadAll(req.Body)
 				if err != nil {
 					return nil, fmt.Errorf("error reading request body")


### PR DESCRIPTION
## Changes

* Add the ability for the retry tripperware to setup buffers that can be used to read the request body multiple times if it doesn't have a GetBody property.
* Add an option to allow turning the above behaviour on.
* Testing updated

## Verification

Retry tripperware integration tests added to and passing
