### PR TITLE
Fix ticker leak in retry tripperware.

### DIFF
--- a/retry/tripperware.go
+++ b/retry/tripperware.go
@@ -69,7 +69,7 @@ func waitRetryBackoff(attempt uint, parentCtx context.Context, opt *options) err
 		select {
 		case <-parentCtx.Done():
 			return parentCtx.Err()
-		case <-time.Tick(waitTime):
+		case <-time.After(waitTime):
 		}
 	}
 	return nil


### PR DESCRIPTION
## Changes

Use `time.After` to avoid resource leak in retry tripperware.

`time.Tick` starts a ticker that is never shut down. `time.After` emits a single event and is then cleaned up fully.

## Verification

None