### PR TITLE
Fix opentracing log formatting.

### DIFF
--- a/tracing/opentracing/middleware.go
+++ b/tracing/opentracing/middleware.go
@@ -89,5 +89,4 @@ func logServerErr(req *http.Request, fmt string, args ...interface{}) {
 	} else {
 		log.Printf(fmt, args...)
 	}
-
 }

--- a/tracing/opentracing/middleware.go
+++ b/tracing/opentracing/middleware.go
@@ -86,11 +86,11 @@ func operationNameFromReqHandler(req *http.Request) string {
 func logServerErr(req *http.Request, fmt string, args ...interface{}) {
 	if v, ok := req.Context().Value(http.ServerContextKey).(*http.Server); ok {
 		if logger := v.ErrorLog; logger != nil {
-			logger.Printf(fmt, args)
+			logger.Printf(fmt, args...)
 		} else {
-			log.Printf(fmt, args)
+			log.Printf(fmt, args...)
 		}
 	} else {
-		log.Printf(fmt, args)
+		log.Printf(fmt, args...)
 	}
 }

--- a/tracing/opentracing/middleware.go
+++ b/tracing/opentracing/middleware.go
@@ -84,13 +84,10 @@ func operationNameFromReqHandler(req *http.Request) string {
 }
 
 func logServerErr(req *http.Request, fmt string, args ...interface{}) {
-	if v, ok := req.Context().Value(http.ServerContextKey).(*http.Server); ok {
-		if logger := v.ErrorLog; logger != nil {
-			logger.Printf(fmt, args...)
-		} else {
-			log.Printf(fmt, args...)
-		}
+	if v, ok := req.Context().Value(http.ServerContextKey).(*http.Server); ok && v.ErrorLog != nil {
+		v.ErrorLog.Printf(fmt, args...)
 	} else {
 		log.Printf(fmt, args...)
 	}
+
 }


### PR DESCRIPTION
## Changes

Correctly spread the formatting args when calling the logger's `Printf` function.

## Verification

None.